### PR TITLE
Feature: Codepoint persistence

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -15,6 +15,6 @@ mv .fontcustom-manifest.json~ .fontcustom-manifest.json
 fontcustom compile -F
 
 # Save used codepoint allocation (which can differ if glyphs were added/removed without updating glyphs.json)
-jq '.glyphs' .fontcustom-manifest.json > glyphs.json
+jq '.glyphs|to_entries|sort_by(.value)|from_entries' .fontcustom-manifest.json > glyphs.json
 
 wkhtmltoimage --enable-local-file-access --crop-w 888 ./assets/icon_preview.html ./assets/preview.png

--- a/compile.sh
+++ b/compile.sh
@@ -1,5 +1,20 @@
 #! /usr/bin/env bash
 set -e
 
+if [ ! -e ".fontcustom-manifest.json" ]; then
+	# Dummy run, just create manifest from fontcustom.yml
+	fontcustom compile >/dev/null 2>&1 || \
+		fontcustom compile # run again in case of error to show messages
+fi
+
+# Patch in our glyph <-> codepoint table
+jq --slurpfile my glyphs.json '.glyphs=$my[0]' .fontcustom-manifest.json > .fontcustom-manifest.json~
+mv .fontcustom-manifest.json~ .fontcustom-manifest.json
+
+# Do the actual work
 fontcustom compile -F
+
+# Save used codepoint allocation (which can differ if glyphs were added/removed without updating glyphs.json)
+jq '.glyphs' .fontcustom-manifest.json > glyphs.json
+
 wkhtmltoimage --enable-local-file-access --crop-w 888 ./assets/icon_preview.html ./assets/preview.png

--- a/glyphs.json
+++ b/glyphs.json
@@ -1,0 +1,186 @@
+{
+  "almalinux": {
+    "codepoint": 61742,
+    "source": "vectors/almalinux.svg"
+  },
+  "alpine": {
+    "codepoint": 61696,
+    "source": "vectors/alpine.svg"
+  },
+  "aosc": {
+    "codepoint": 61697,
+    "source": "vectors/aosc.svg"
+  },
+  "apple": {
+    "codepoint": 61698,
+    "source": "vectors/apple.svg"
+  },
+  "archlabs": {
+    "codepoint": 61735,
+    "source": "vectors/archlabs.svg"
+  },
+  "archlinux": {
+    "codepoint": 61699,
+    "source": "vectors/archlinux.svg"
+  },
+  "artix": {
+    "codepoint": 61740,
+    "source": "vectors/artix.svg"
+  },
+  "budgie": {
+    "codepoint": 61730,
+    "source": "vectors/budgie.svg"
+  },
+  "centos": {
+    "codepoint": 61700,
+    "source": "vectors/centos.svg"
+  },
+  "coreos": {
+    "codepoint": 61701,
+    "source": "vectors/coreos.svg"
+  },
+  "debian": {
+    "codepoint": 61702,
+    "source": "vectors/debian.svg"
+  },
+  "deepin": {
+    "codepoint": 61731,
+    "source": "vectors/deepin.svg"
+  },
+  "devuan": {
+    "codepoint": 61703,
+    "source": "vectors/devuan.svg"
+  },
+  "docker": {
+    "codepoint": 61704,
+    "source": "vectors/docker.svg"
+  },
+  "elementary": {
+    "codepoint": 61705,
+    "source": "vectors/elementary.svg"
+  },
+  "fedora": {
+    "codepoint": 61706,
+    "source": "vectors/fedora.svg"
+  },
+  "fedora-inverse": {
+    "codepoint": 61707,
+    "source": "vectors/fedora-inverse.svg"
+  },
+  "ferris": {
+    "codepoint": 61736,
+    "source": "vectors/ferris.svg"
+  },
+  "flathub": {
+    "codepoint": 61725,
+    "source": "vectors/flathub.svg"
+  },
+  "freebsd": {
+    "codepoint": 61708,
+    "source": "vectors/freebsd.svg"
+  },
+  "gentoo": {
+    "codepoint": 61709,
+    "source": "vectors/gentoo.svg"
+  },
+  "gnu-guix": {
+    "codepoint": 61726,
+    "source": "vectors/gnu-guix.svg"
+  },
+  "illumos": {
+    "codepoint": 61732,
+    "source": "vectors/illumos.svg"
+  },
+  "kali-linux": {
+    "codepoint": 61741,
+    "source": "vectors/kali-linux.svg"
+  },
+  "linuxmint": {
+    "codepoint": 61710,
+    "source": "vectors/linuxmint.svg"
+  },
+  "linuxmint-inverse": {
+    "codepoint": 61711,
+    "source": "vectors/linuxmint-inverse.svg"
+  },
+  "mageia": {
+    "codepoint": 61712,
+    "source": "vectors/mageia.svg"
+  },
+  "mandriva": {
+    "codepoint": 61713,
+    "source": "vectors/mandriva.svg"
+  },
+  "manjaro": {
+    "codepoint": 61714,
+    "source": "vectors/manjaro.svg"
+  },
+  "nixos": {
+    "codepoint": 61715,
+    "source": "vectors/nixos.svg"
+  },
+  "openbsd": {
+    "codepoint": 61733,
+    "source": "vectors/openbsd.svg"
+  },
+  "opensuse": {
+    "codepoint": 61716,
+    "source": "vectors/opensuse.svg"
+  },
+  "pop-os": {
+    "codepoint": 61739,
+    "source": "vectors/pop-os.svg"
+  },
+  "raspberry-pi": {
+    "codepoint": 61717,
+    "source": "vectors/raspberry-pi.svg"
+  },
+  "redhat": {
+    "codepoint": 61718,
+    "source": "vectors/redhat.svg"
+  },
+  "rocky-linux": {
+    "codepoint": 61743,
+    "source": "vectors/rocky-linux.svg"
+  },
+  "sabayon": {
+    "codepoint": 61719,
+    "source": "vectors/sabayon.svg"
+  },
+  "slackware": {
+    "codepoint": 61720,
+    "source": "vectors/slackware.svg"
+  },
+  "slackware-inverse": {
+    "codepoint": 61721,
+    "source": "vectors/slackware-inverse.svg"
+  },
+  "snappy": {
+    "codepoint": 61727,
+    "source": "vectors/snappy.svg"
+  },
+  "solus": {
+    "codepoint": 61734,
+    "source": "vectors/solus.svg"
+  },
+  "tux": {
+    "codepoint": 61722,
+    "source": "vectors/tux.svg"
+  },
+  "ubuntu": {
+    "codepoint": 61723,
+    "source": "vectors/ubuntu.svg"
+  },
+  "ubuntu-inverse": {
+    "codepoint": 61724,
+    "source": "vectors/ubuntu-inverse.svg"
+  },
+  "void": {
+    "codepoint": 61728,
+    "source": "vectors/void.svg"
+  },
+  "zorin": {
+    "codepoint": 61729,
+    "source": "vectors/zorin.svg"
+  }
+}

--- a/glyphs.json
+++ b/glyphs.json
@@ -1,8 +1,4 @@
 {
-  "almalinux": {
-    "codepoint": 61738,
-    "source": "vectors/almalinux.svg"
-  },
   "alpine": {
     "codepoint": 61696,
     "source": "vectors/alpine.svg"
@@ -15,21 +11,9 @@
     "codepoint": 61698,
     "source": "vectors/apple.svg"
   },
-  "archlabs": {
-    "codepoint": 61735,
-    "source": "vectors/archlabs.svg"
-  },
   "archlinux": {
     "codepoint": 61699,
     "source": "vectors/archlinux.svg"
-  },
-  "artix": {
-    "codepoint": 61740,
-    "source": "vectors/artix.svg"
-  },
-  "budgie": {
-    "codepoint": 61730,
-    "source": "vectors/budgie.svg"
   },
   "centos": {
     "codepoint": 61700,
@@ -42,10 +26,6 @@
   "debian": {
     "codepoint": 61702,
     "source": "vectors/debian.svg"
-  },
-  "deepin": {
-    "codepoint": 61731,
-    "source": "vectors/deepin.svg"
   },
   "devuan": {
     "codepoint": 61703,
@@ -67,14 +47,6 @@
     "codepoint": 61707,
     "source": "vectors/fedora-inverse.svg"
   },
-  "ferris": {
-    "codepoint": 61736,
-    "source": "vectors/ferris.svg"
-  },
-  "flathub": {
-    "codepoint": 61725,
-    "source": "vectors/flathub.svg"
-  },
   "freebsd": {
     "codepoint": 61708,
     "source": "vectors/freebsd.svg"
@@ -82,18 +54,6 @@
   "gentoo": {
     "codepoint": 61709,
     "source": "vectors/gentoo.svg"
-  },
-  "gnu-guix": {
-    "codepoint": 61726,
-    "source": "vectors/gnu-guix.svg"
-  },
-  "illumos": {
-    "codepoint": 61732,
-    "source": "vectors/illumos.svg"
-  },
-  "kali-linux": {
-    "codepoint": 61741,
-    "source": "vectors/kali-linux.svg"
   },
   "linuxmint": {
     "codepoint": 61710,
@@ -119,17 +79,9 @@
     "codepoint": 61715,
     "source": "vectors/nixos.svg"
   },
-  "openbsd": {
-    "codepoint": 61733,
-    "source": "vectors/openbsd.svg"
-  },
   "opensuse": {
     "codepoint": 61716,
     "source": "vectors/opensuse.svg"
-  },
-  "pop-os": {
-    "codepoint": 61739,
-    "source": "vectors/pop-os.svg"
   },
   "raspberry-pi": {
     "codepoint": 61717,
@@ -138,10 +90,6 @@
   "redhat": {
     "codepoint": 61718,
     "source": "vectors/redhat.svg"
-  },
-  "rocky-linux": {
-    "codepoint": 61737,
-    "source": "vectors/rocky-linux.svg"
   },
   "sabayon": {
     "codepoint": 61719,
@@ -155,14 +103,6 @@
     "codepoint": 61721,
     "source": "vectors/slackware-inverse.svg"
   },
-  "snappy": {
-    "codepoint": 61727,
-    "source": "vectors/snappy.svg"
-  },
-  "solus": {
-    "codepoint": 61734,
-    "source": "vectors/solus.svg"
-  },
   "tux": {
     "codepoint": 61722,
     "source": "vectors/tux.svg"
@@ -175,6 +115,18 @@
     "codepoint": 61724,
     "source": "vectors/ubuntu-inverse.svg"
   },
+  "flathub": {
+    "codepoint": 61725,
+    "source": "vectors/flathub.svg"
+  },
+  "gnu-guix": {
+    "codepoint": 61726,
+    "source": "vectors/gnu-guix.svg"
+  },
+  "snappy": {
+    "codepoint": 61727,
+    "source": "vectors/snappy.svg"
+  },
   "void": {
     "codepoint": 61728,
     "source": "vectors/void.svg"
@@ -182,5 +134,53 @@
   "zorin": {
     "codepoint": 61729,
     "source": "vectors/zorin.svg"
+  },
+  "budgie": {
+    "codepoint": 61730,
+    "source": "vectors/budgie.svg"
+  },
+  "deepin": {
+    "codepoint": 61731,
+    "source": "vectors/deepin.svg"
+  },
+  "illumos": {
+    "codepoint": 61732,
+    "source": "vectors/illumos.svg"
+  },
+  "openbsd": {
+    "codepoint": 61733,
+    "source": "vectors/openbsd.svg"
+  },
+  "solus": {
+    "codepoint": 61734,
+    "source": "vectors/solus.svg"
+  },
+  "archlabs": {
+    "codepoint": 61735,
+    "source": "vectors/archlabs.svg"
+  },
+  "ferris": {
+    "codepoint": 61736,
+    "source": "vectors/ferris.svg"
+  },
+  "rocky-linux": {
+    "codepoint": 61737,
+    "source": "vectors/rocky-linux.svg"
+  },
+  "almalinux": {
+    "codepoint": 61738,
+    "source": "vectors/almalinux.svg"
+  },
+  "pop-os": {
+    "codepoint": 61739,
+    "source": "vectors/pop-os.svg"
+  },
+  "artix": {
+    "codepoint": 61740,
+    "source": "vectors/artix.svg"
+  },
+  "kali-linux": {
+    "codepoint": 61741,
+    "source": "vectors/kali-linux.svg"
   }
 }

--- a/glyphs.json
+++ b/glyphs.json
@@ -1,6 +1,6 @@
 {
   "almalinux": {
-    "codepoint": 61742,
+    "codepoint": 61738,
     "source": "vectors/almalinux.svg"
   },
   "alpine": {

--- a/glyphs.json
+++ b/glyphs.json
@@ -140,7 +140,7 @@
     "source": "vectors/redhat.svg"
   },
   "rocky-linux": {
-    "codepoint": 61743,
+    "codepoint": 61737,
     "source": "vectors/rocky-linux.svg"
   },
   "sabayon": {


### PR DESCRIPTION
**[why]**
When codepoints are changed for the individual logos that should be a
deliberate decision.

**[how]**
We have now a dedicated file for the codepoint to logo mapping. That
will be used for the font generation: `glyphs.json`.

If new logos show up or exisiting ones are deleted this will change that
dedicated file when `compile.sh` is called and what happened is clearly
visible in the changed git status.

People who add / remove a logo have to run `compile.sh` and afterwards
review the changes in the `glyphs.json` file and include that changes in
their commit.

**[note]**
This is only slightly different to the formerly used solution: Keep the
`.fontcustom-manifest.json` in git. But that has been removed with
commit f161cf6 for some reason. Maybe because that file is hidden, which
is not so nice.

This PR just preserves the "glyphs" section of the manifest and extracts
it into a dedicated file, that can be added and reviewed.

**[note]**
Glyph codepoints reverted back to `f161cf6^` i.e. 12f3783 (a.k.a. v0.17)

Fixes #33
Fixes #72

---

After pulling this we would need a new release, either 0.18.1 or 0.19 or something.

Here the (new) codepoint allocation:

![image](https://user-images.githubusercontent.com/16012374/151149522-9b75e9e8-fed3-4208-8284-5e0be74654eb.png)
