### PR TITLE
CI: Automate release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,21 @@ jobs:
         run: |
           make
 
+      - name: Crate archive
+        run: |
+          PKGDIR=font-logos-${{ env.RELEASE_VERSION }}
+          ZIPFILE="${PKGDIR}.zip"
+          rsync --info=name LICENSE "${PKGDIR}/"
+          rsync --info=name package.json "${PKGDIR}/"
+          rsync --info=name README.md "${PKGDIR}/"
+          rsync --info=name -R assets/*.css "${PKGDIR}/"
+          rsync --info=name -R assets/*.ttf "${PKGDIR}/"
+          rsync --info=name -R assets/*.woff "${PKGDIR}/"
+          rsync --info=name -R assets/*.woff2 "${PKGDIR}/"
+          rsync --info=name -R vectors/*.svg "${PKGDIR}/"
+          zip -r "${ZIPFILE}" "${PKGDIR}"
+          echo "ZIPFILE=${ZIPFILE}" >> $GITHUB_ENV
+
       - name: Adjust release tag
         uses: EndBug/latest-tag@v1.5.1
         with:
@@ -40,12 +55,5 @@ jobs:
           draft: true
           tag_name: "v${{ env.RELEASE_VERSION }}"
           files: |
-            LICENSE
-            package.json
-            README.md
-            assets/*.css
-            assets/*.ttf
-            assets/*.woff
-            assets/*.woff2
-            vectors/*.svg
+            ${{ env.ZIPFILE }}
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+# This creates a Release Draft
+# Adjust the release message in the web GUI and publish the release there.
+
+name: Draft a Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  setup-release-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch repo
+        uses: actions/checkout@v3
+
+      - name: Fetch dependencies
+        run: |
+          sudo apt update -y -q
+          sudo apt install python3-fontforge jq nodejs wkhtmltopdf -y -q
+          npm install nunjucks
+
+      - name: Determine version
+        run: |
+          REL_VERSION=$(jq -r '.version' package.json)
+          echo "Release version ${REL_VERSION}"
+          echo "RELEASE_VERSION=${REL_VERSION}" >> $GITHUB_ENV
+
+      - name: Create the assets
+        run: |
+          make
+
+      - name: Adjust release tag
+        uses: EndBug/latest-tag@v1.5.1
+        with:
+          ref: "v${{ env.RELEASE_VERSION }}"
+
+      - name: Create release draft
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          draft: true
+          tag_name: "v${{ env.RELEASE_VERSION }}"
+          files: |
+            LICENSE
+            package.json
+            README.md
+            assets/*.css
+            assets/*.ttf
+            assets/*.woff
+            assets/*.woff2
+            vectors/*.svg
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fetch dependencies
         run: |
@@ -45,7 +45,7 @@ jobs:
           echo "ZIPFILE=${ZIPFILE}" >> $GITHUB_ENV
 
       - name: Adjust release tag
-        uses: EndBug/latest-tag@v1.5.1
+        uses: EndBug/latest-tag@v1.6.1
         with:
           ref: "v${{ env.RELEASE_VERSION }}"
 

--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -1,0 +1,52 @@
+# This pushes out a new npm release
+# It will be triggered once the release draft is published
+
+name: Publish release to npm
+
+on:
+  release:
+    types:
+      - released
+  workflow_dispatch:
+
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if we are on correct commit
+        run: |
+          REL_VERSION=v$(jq -r '.version' package.json)
+          GIT_VERSION=$(git describe --tags)
+          echo "Release version ${REL_VERSION}"
+          echo "Git tag version ${GIT_VERSION}"
+          if [ "${REL_VERSION}" != "${GIT_VERSION}" ]; then \
+              echo "This is probably not what you want"; \
+              exit 1; \
+          fi
+
+      - name: Fetch dependencies
+        run: |
+          sudo apt update -y -q
+          sudo apt install python3-fontforge jq nodejs wkhtmltopdf -y -q
+          npm install nunjucks
+
+      - name: Setup .npmrc file to publish to npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Build the artifacts
+        run: |
+          npm ci
+
+      - name: Publish to npm
+        run: |
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fetch dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -121,3 +121,22 @@ Make sure you have the following dependencies installed:
 * [wkhtmltopdf](http://wkhtmltopdf.org/) to generate this readme's preview image
 
 Then run `npm install`/`yarn install` and `make`.
+
+## Releasing ##
+
+If you are a maintainer of this repository and a new release is to be published
+* Make shure all PRs (that shall be pulled) are pulled
+  * The PRs add new `svg`s in `vectors/`
+  * The `icons.tsv` is ammended (i.e. new icons added at the bottom)
+* Every time the `svg`s or `icons.tsv` is touched in the `master` brauch (i.e. through pulling) the preview image is updated
+* Note that the `README.md` is NOT updated. You can manually modify it do indicate/add recently added but not released icons.
+* One the release seems ready:
+* Edit the version number in `package.json` (and push that change to `master`)
+* Trigger the "Draft a Release" workflow manually on the Actions page (on the `master` branch)
+  * The workflow will add a git tag for the release
+* Go to the releases list and find the draft release
+  * Edit the description etc pp and finally
+  * Push "publish release"
+  * The release is published on Github
+* Automatically the "Publish release to npm" workflow is triggered
+  * If the npm token is not expired the release is pushed to nodejs

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   ],
   "license": "Unlicense",
   "homepage": "https://github.com/Lukas-W/font-logos",
-  "repository": "https://github.com/Lukas-W/font-logos.git",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Lukas-W/font-logos.git"
+  },
   "scripts": {
     "build": "make"
   },
@@ -22,6 +25,6 @@
   ],
   "devDependencies": {
     "lodash.merge": "^4.6.2",
-    "nunjucks": "^3.2.3"
+    "nunjucks": "^3.2.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,27 +4,27 @@
 
 a-sync-waterfall@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz#75b6b6aa72598b497a125e7a2770f14f4c8a1fa7"
+  resolved "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz"
   integrity sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==
 
 asap@^2.0.3:
   version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  resolved "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
 commander@^5.1.0:
   version "5.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
+  resolved "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-nunjucks@^3.2.3:
+nunjucks@^3.2.4:
   version "3.2.4"
-  resolved "https://registry.yarnpkg.com/nunjucks/-/nunjucks-3.2.4.tgz#f0878eef528ce7b0aa35d67cc6898635fd74649e"
+  resolved "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz"
   integrity sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==
   dependencies:
     a-sync-waterfall "^1.0.0"


### PR DESCRIPTION
[why]
Releasing is too hard.

[how]
The maintainer needs to set a new version in the package.json. Afterwards the release draft creator can be manually triggered on the Actions tab of the Github repo.

This will draft a release with a new font generated from the current vectors. And the current commit will be git tagged with the release version.

Fixes: #29