### PR TITLE
Fix: doc: Add releasing instructions

### DIFF
--- a/templates/README.md.njk
+++ b/templates/README.md.njk
@@ -62,10 +62,10 @@ Then run `npm install`/`yarn install` and `make`.
 ## Releasing ##
 
 If you are a maintainer of this repository and a new release is to be published
-* Make shure all PRs (that shall be pulled) are pulled
+* Make sure all PRs (that shall be pulled) are pulled
   * The PRs add new `svg`s in `vectors/`
   * The `icons.tsv` is ammended (i.e. new icons added at the bottom)
-* Every time the `svg`s or `icons.tsv` is touched in the `master` brauch (i.e. through pulling) the preview image is updated
+* Every time the `svg`s or `icons.tsv` is touched in the `master` branch (i.e. through pulling) the preview image is updated
 * Note that the `README.md` is NOT updated. You can manually modify it do indicate/add recently added but not released icons.
 * Once the release seems ready:
 * Edit the version number in `package.json` (and push that change to `master`)

--- a/templates/README.md.njk
+++ b/templates/README.md.njk
@@ -58,3 +58,22 @@ Make sure you have the following dependencies installed:
 * [wkhtmltopdf](http://wkhtmltopdf.org/) to generate this readme's preview image
 
 Then run `npm install`/`yarn install` and `make`.
+
+## Releasing ##
+
+If you are a maintainer of this repository and a new release is to be published
+* Make shure all PRs (that shall be pulled) are pulled
+  * The PRs add new `svg`s in `vectors/`
+  * The `icons.tsv` is ammended (i.e. new icons added at the bottom)
+* Every time the `svg`s or `icons.tsv` is touched in the `master` brauch (i.e. through pulling) the preview image is updated
+* Note that the `README.md` is NOT updated. You can manually modify it do indicate/add recently added but not released icons.
+* Once the release seems ready:
+* Edit the version number in `package.json` (and push that change to `master`)
+* Trigger the "Draft a Release" workflow manually on the Actions page (on the `master` branch)
+  * The workflow will add a git tag for the release
+* Go to the releases list and find the draft release
+  * Edit the description etc pp and finally
+  * Push "publish release"
+  * The release is published on Github
+* Automatically the "Publish release to npm" workflow is triggered
+  * If the npm token is not expired the release is pushed to NPM


### PR DESCRIPTION
[why]
The generated file had been changed instead of the template.

@hasecilu 

Please just merge this whenever convenient. But before releasing.

Do you want to trigger the release after the 3 PRs are merged?
I'm quite confident that the workflows will do the job, but ... you never know.
If we coordinate a time for the release I can be there to fix stuff that broke :grimacing: 