### PR TITLE
Fix copyright in font files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ export START_CODEPOINT
 export FONT_NAME=$(name)
 export OUTPUT_DIR=$(dest)
 export JSON_FILE=$(json_file)
+export COPYRIGHT=Copyright (c) $(date '+%Y'), Lukas W
 
 all_files=$(font_assets) $(dest)/$(name).css $(dest)/preview.html $(dest)/readme-header.png README.md
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ export FONT_NAME=$(name)
 export OUTPUT_DIR=$(dest)
 export JSON_FILE=$(json_file)
 export COPYRIGHT=Copyright (c) $(date '+%Y'), Lukas W
+export VENDORURL=https://github.com/lukas-w/font-logos
 
 all_files=$(font_assets) $(dest)/$(name).css $(dest)/preview.html $(dest)/readme-header.png README.md
 

--- a/scripts/generate-font.py
+++ b/scripts/generate-font.py
@@ -54,6 +54,7 @@ for iconId, icon in fontData['icons'].items():
 	addIcon(iconId, icon)
 
 font.appendSFNTName("English (US)", "Version", fontData['version']['string'])
+font.appendSFNTName("English (US)", "Vendor URL", os.environ['VENDORURL'])
 font.version = fontData['version']['string']
 
 font.generate(os.path.join(outputdir, fontname + '.ttf'))

--- a/scripts/generate-font.py
+++ b/scripts/generate-font.py
@@ -20,6 +20,7 @@ font.familyname = fontname
 font.fullname = fontname
 font.design_size = font_design_size
 font.em = font_em
+font.copyright = os.environ['COPYRIGHT']
 
 # if autowidth:
 # font.autoWidth(0, 0, font.em)


### PR DESCRIPTION
[why]
The copyright in the font files are unspecified at the moment and Fontforge fills in something deduced from the current user.

[how]
Specify a concrete copyright value that matches the values the previous releases had.

[note]
https://github.com/lukas-w/font-logos/issues/72#issuecomment-1175881955