### PR TITLE
Add `shell` on Makefile command to make year appear on metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ export START_CODEPOINT
 export FONT_NAME=$(name)
 export OUTPUT_DIR=$(dest)
 export JSON_FILE=$(json_file)
-export COPYRIGHT=Copyright (c) $(date '+%Y'), Lukas W
+export COPYRIGHT=Copyright (c) 2014-$(shell date '+%Y'), Lukas W
 export VENDORURL=$(shell jq -r .homepage package.json)
 
 all_files=$(font_assets) $(dest)/$(name).css $(dest)/preview.html $(dest)/readme-header.png README.md


### PR DESCRIPTION
It seems the shell should used in order to `date` be used as command and not as a variable.
![image](https://github.com/lukas-w/font-logos/assets/53124818/b552d605-512f-4186-85ee-5d05fd65fdd3)
