### PR TITLE
Automatic Readme Generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,12 +55,12 @@ jobs:
           echo "filename=${ZIPFILE}" >> $GITHUB_OUTPUT
 
       - name: Adjust release tag
-        uses: EndBug/latest-tag@v1.6.1
+        uses: EndBug/latest-tag@v1.6.2
         with:
           ref: "v${{ steps.rel_ver.outputs.ver }}"
 
       - name: Create release draft
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2
         with:
           draft: true
           tag_name: "v${{ steps.rel_ver.outputs.ver }}"

--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -52,7 +52,7 @@ jobs:
           fontforge --version
 
       - name: Setup .npmrc file to publish to npm
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Commit preview image back to repo
         uses: EndBug/add-and-commit@v9
         with:
-          fetch: false
           add: 'assets/readme-header.png'
           message: "[ci] Update preview image"
           committer_name: GitHub Actions

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -1,7 +1,7 @@
-# This pushes out a new npm release
+# This creates and commits an updated readme
 # It will be triggered once the release draft is published
 
-name: Publish release to npm
+name: Update README
 
 on:
   release:
@@ -51,19 +51,16 @@ jobs:
           echo Try appimage with path
           fontforge --version
 
-      - name: Setup .npmrc file to publish to npm
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-
       - name: Build the artifacts
         run: |
           npm ci
           make
 
-      - name: Publish to npm
-        run: |
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Commit new README back to repo
+        uses: EndBug/add-and-commit@v9
+        with:
+          fetch: false
+          add: 'README.md'
+          message: "[ci] Update README.md"
+          committer_name: GitHub Actions
+          committer_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Commit new README back to repo
         uses: EndBug/add-and-commit@v9
         with:
-          fetch: false
           add: 'README.md'
           message: "[ci] Update README.md"
           committer_name: GitHub Actions

--- a/templates/README.md.njk
+++ b/templates/README.md.njk
@@ -75,6 +75,8 @@ If you are a maintainer of this repository and a new release is to be published
   * Edit the description etc pp and finally
   * Push "publish release"
   * The release is published on Github
+* Automatically the "Update README" workflow is triggered
+  * The `README.md` is regenerated (the preview should already be up to date, see above)
 * Automatically the "Publish release to npm" workflow is triggered
   * If the npm token is not expired the release is pushed to NPM
-  * The `README.md` is regenerated (the preview should already be up to date, see above)
+  * You need to publish on NPM manually if token is expired (expected)


### PR DESCRIPTION
We want to update the README even when NPM fails.

Maybe even have a 'knob' to update it at will.

Also update actions to Node20.

Fixes: #117 